### PR TITLE
Added DeleteQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.0
+
+* [#15](https://github.com/squigglesql/squigglesql/pull/15): Added DeleteQuery
+
 # 4.1.0
 
 * :boom: **Breaking change.** Criteria implementations should now be accessed via static methods, e.g. Criteria.equal,

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.squigglesql</groupId>
     <artifactId>squigglesql</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
     <url>https://github.com/squigglesql/squigglesql</url>
     <licenses>
         <license>

--- a/src/main/java/com/github/squigglesql/squigglesql/query/DeleteQuery.java
+++ b/src/main/java/com/github/squigglesql/squigglesql/query/DeleteQuery.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Cody Ebberson.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.squigglesql.squigglesql.query;
+
+import com.github.squigglesql.squigglesql.Output;
+import com.github.squigglesql.squigglesql.QueryCompiler;
+import com.github.squigglesql.squigglesql.TableReference;
+import com.github.squigglesql.squigglesql.alias.AliasGenerator;
+import com.github.squigglesql.squigglesql.criteria.Criteria;
+import com.github.squigglesql.squigglesql.statement.StatementBuilder;
+import com.github.squigglesql.squigglesql.statement.StatementCompiler;
+import com.github.squigglesql.squigglesql.util.CollectionWriter;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * SQL delete query.
+ *
+ * @since 4.2.0
+ */
+public class DeleteQuery extends Query {
+    
+    private final TableReference tableReference;
+    private final List<Criteria> criterias = new ArrayList<>();
+
+    /**
+     * Creates a delete query.
+     *
+     * @param tableReference table reference to delete rows from.
+     */
+    public DeleteQuery(TableReference tableReference) {
+        if (tableReference == null) {
+            throw new IllegalArgumentException("Table reference can not be empty.");
+        }
+        this.tableReference = tableReference;
+    }
+
+    /**
+     * Adds a criteria to "WHERE" section of the query. Criterias are joined with "AND" operator.
+     *
+     * @param criteria criteria to add.
+     */
+    public void addCriteria(Criteria criteria) {
+        if (criteria == null) {
+            throw new IllegalArgumentException("Criteria can not be null.");
+        }
+        this.criterias.add(criteria);
+    }
+
+    @Override
+    protected void compile(Output output) {
+        Set<TableReference> tableReferences = findTableReferences();
+
+        if (tableReferences.size() > 1) {
+            throw new IllegalArgumentException("Cannot delete using multiple tables.");
+        }
+
+        QueryCompiler queryCompiler = new QueryCompiler(output,
+                AliasGenerator.generateAliases(tableReferences, TABLE_REFERENCE_ALIAS_ALPHABET));
+
+        output.getSyntax().compileDeleteFrom(queryCompiler, tableReference);
+
+        if (criterias.size() > 0) {
+            queryCompiler.write("WHERE");
+            CollectionWriter.writeCollection(queryCompiler, criterias, " AND", false, true);
+        }
+    }
+
+    @Override
+    protected <S> StatementBuilder<S> createStatementBuilder(StatementCompiler<S> compiler, String query)
+            throws SQLException {
+        return compiler.createStatementBuilder(query);
+    }
+
+    private Set<TableReference> findTableReferences() {
+        Set<TableReference> tables = new LinkedHashSet<>();
+        tables.add(tableReference);
+        for (Criteria criteria : criterias) {
+            criteria.collectTableReferences(tables);
+        }
+        return tables;
+    }
+}

--- a/src/main/java/com/github/squigglesql/squigglesql/syntax/AbstractSqlSyntax.java
+++ b/src/main/java/com/github/squigglesql/squigglesql/syntax/AbstractSqlSyntax.java
@@ -17,6 +17,7 @@ package com.github.squigglesql.squigglesql.syntax;
 
 import com.github.squigglesql.squigglesql.Matchable;
 import com.github.squigglesql.squigglesql.QueryCompiler;
+import com.github.squigglesql.squigglesql.TableReference;
 
 /**
  * Abstract SQL syntax. Describes database-specific SQL features necessary to compile a query. You may use
@@ -81,4 +82,14 @@ public interface AbstractSqlSyntax {
      * @since 4.1.0
      */
     void compileIsNotDistinctFrom(QueryCompiler compiler, Matchable left, Matchable right);
+
+    /**
+     * Compiles "DELETE FROM table" with table aliases.  Some databases have special requirements for how the
+     * table is specified when using table aliases.
+     *
+     * @param compiler       compiler to compile the query with.
+     * @param tableReference the table to delete rows from.
+     * @since 4.2.0
+     */
+    void compileDeleteFrom(QueryCompiler compiler, TableReference tableReference);
 }

--- a/src/main/java/com/github/squigglesql/squigglesql/syntax/CommonSqlSyntax.java
+++ b/src/main/java/com/github/squigglesql/squigglesql/syntax/CommonSqlSyntax.java
@@ -17,6 +17,7 @@ package com.github.squigglesql.squigglesql.syntax;
 
 import com.github.squigglesql.squigglesql.Matchable;
 import com.github.squigglesql.squigglesql.QueryCompiler;
+import com.github.squigglesql.squigglesql.TableReference;
 
 abstract class CommonSqlSyntax implements AbstractSqlSyntax {
 
@@ -60,5 +61,10 @@ abstract class CommonSqlSyntax implements AbstractSqlSyntax {
     @Override
     public void compileIsNotDistinctFrom(QueryCompiler compiler, Matchable left, Matchable right) {
         compiler.write(left).write(" IS NOT DISTINCT FROM ").write(right);
+    }
+
+    @Override
+    public void compileDeleteFrom(QueryCompiler compiler, TableReference tableReference) {
+        compiler.writeln("DELETE FROM").indent().writeln(tableReference).unindent();
     }
 }

--- a/src/main/java/com/github/squigglesql/squigglesql/syntax/MySqlSyntax.java
+++ b/src/main/java/com/github/squigglesql/squigglesql/syntax/MySqlSyntax.java
@@ -17,6 +17,7 @@ package com.github.squigglesql.squigglesql.syntax;
 
 import com.github.squigglesql.squigglesql.Matchable;
 import com.github.squigglesql.squigglesql.QueryCompiler;
+import com.github.squigglesql.squigglesql.TableReference;
 
 class MySqlSyntax extends CommonSqlSyntax {
 
@@ -38,5 +39,15 @@ class MySqlSyntax extends CommonSqlSyntax {
     @Override
     public void compileIsNotDistinctFrom(QueryCompiler compiler, Matchable left, Matchable right) {
         compiler.write(left).write(" <=> ").write(right);
+    }
+
+    @Override
+    public void compileDeleteFrom(QueryCompiler compiler, TableReference tableReference) {
+        compiler.write("DELETE ")
+                .quote(compiler.getAlias(tableReference), getTableReferenceQuote())
+                .writeln(" FROM")
+                .indent()
+                .writeln(tableReference)
+                .unindent();
     }
 }

--- a/src/test/java/com/github/squigglesql/squigglesql/DeleteQueryTest.java
+++ b/src/test/java/com/github/squigglesql/squigglesql/DeleteQueryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Cody Ebberson.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.squigglesql.squigglesql;
+
+import com.github.squigglesql.squigglesql.mock.MockStatement;
+import com.github.squigglesql.squigglesql.mock.MockStatementCompiler;
+import com.github.squigglesql.squigglesql.parameter.Parameter;
+import com.github.squigglesql.squigglesql.query.DeleteQuery;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+import static com.github.squigglesql.squigglesql.criteria.Criteria.equal;
+import static org.junit.Assert.assertEquals;
+
+public class DeleteQueryTest {
+
+    @Test
+    public void testDeleteQuery() throws SQLException {
+        Table employee = new Table("employee");
+        TableColumn employeeId = employee.get("id");
+
+        TableReference e = employee.refer();
+
+        DeleteQuery query = new DeleteQuery(e);
+        query.addCriteria(equal(e.get(employeeId), Parameter.of("<employee_id_value>")));
+
+        MockStatement statement = query.toStatement(new MockStatementCompiler());
+
+        assertEquals("DELETE FROM\n"
+                + "    employee e\n"
+                + "WHERE\n"
+                + "    e.id = ?", statement.getQuery());
+        assertEquals(1, statement.getParameters().size());
+        assertEquals("<employee_id_value>", statement.getParameters().get(0));
+    }
+
+    @Test()
+    public void testEmptyDelete() throws SQLException {
+        Table employee = new Table("employee");
+        TableReference e = employee.refer();
+        DeleteQuery query = new DeleteQuery(e);
+
+        MockStatement statement = query.toStatement(new MockStatementCompiler());
+
+        assertEquals("DELETE FROM\n"
+                + "    employee e", statement.getQuery());
+        assertEquals(0, statement.getParameters().size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullTableReference() {
+        new DeleteQuery(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullCriteria() {
+        Table employee = new Table("employee");
+        TableReference e = employee.refer();
+        new DeleteQuery(e).addCriteria(null);
+    }
+}

--- a/src/test/java/com/github/squigglesql/squigglesql/DeleteQueryTest.java
+++ b/src/test/java/com/github/squigglesql/squigglesql/DeleteQueryTest.java
@@ -72,4 +72,23 @@ public class DeleteQueryTest {
         TableReference e = employee.refer();
         new DeleteQuery(e).addCriteria(null);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipleTables() throws SQLException {
+        Table employee = new Table("employee");
+        TableColumn employeeId = employee.get("id");
+
+        Table session = new Table("session");
+        TableColumn sessionId = session.get("id");
+        TableColumn sessionEmployeeId = session.get("employee_id");
+
+        TableReference e = employee.refer();
+        TableReference s = session.refer();
+
+        DeleteQuery query = new DeleteQuery(e);
+        query.addCriteria(equal(e.get(employeeId), s.get(sessionEmployeeId)));
+        query.addCriteria(equal(s.get(sessionId), Parameter.of("<session_id_value>")));
+
+        query.toStatement(new MockStatementCompiler());
+    }
 }

--- a/src/test/java/com/github/squigglesql/squigglesql/JdbcTest.java
+++ b/src/test/java/com/github/squigglesql/squigglesql/JdbcTest.java
@@ -15,8 +15,11 @@
  */
 package com.github.squigglesql.squigglesql;
 
+import com.github.squigglesql.squigglesql.criteria.Criteria;
 import com.github.squigglesql.squigglesql.databases.TestDatabaseColumn;
+import com.github.squigglesql.squigglesql.literal.Literal;
 import com.github.squigglesql.squigglesql.parameter.Parameter;
+import com.github.squigglesql.squigglesql.query.DeleteQuery;
 import com.github.squigglesql.squigglesql.query.InsertQuery;
 import com.github.squigglesql.squigglesql.query.ResultColumn;
 import com.github.squigglesql.squigglesql.query.SelectQuery;
@@ -116,6 +119,33 @@ public class JdbcTest {
             UpdateQuery updateQuery = new UpdateQuery(ref);
             updateQuery.addValue(AGE, Parameter.of(BOB_GROWN.getAge()));
             assertEquals(2, JdbcUtils.update(updateQuery, connection));
+        });
+    }
+
+    @Test
+    public void testDelete() throws SQLException {
+        withContents((connection, database) -> {
+            TableReference ref = TABLE.refer();
+            DeleteQuery deleteQuery = new DeleteQuery(ref);
+            deleteQuery.addCriteria(equal(ref.get(ID), Parameter.of(AARON.getId())));
+            assertEquals(1, JdbcUtils.update(deleteQuery, connection));
+
+            SelectQuery selectQuery = new SelectQuery();
+            ResultMapper<Employee> mapper = addToQuery(selectQuery, AARON.getId());
+            Employee employee = JdbcUtils.selectOne(selectQuery, connection, mapper);
+            assertNull(employee);
+        });
+    }
+
+    @Test
+    public void testMultiDelete() throws SQLException {
+        withContents((connection, database) -> {
+            insert(connection, CHRIS);
+
+            TableReference ref = TABLE.refer();
+            DeleteQuery deleteQuery = new DeleteQuery(ref);
+            deleteQuery.addCriteria(Criteria.greater(ref.get(AGE), Literal.of(21)));
+            assertEquals(2, JdbcUtils.update(deleteQuery, connection));
         });
     }
 


### PR DESCRIPTION
Added `DeleteQuery` to delete rows.

The structure follows `UpdateQuery` except without the update values.

MySQL has unique syntax when using table aliases:
* MySQL:  `DELETE e FROM employees e`
* Postgres: `DELETE FROM employees e`

Hence the addition of `AbstractSqlSyntax.compileDeleteFrom`