### PR TITLE
Add module-info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,42 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <module>
+                                <moduleInfoSource>
+                                    module com.github.squigglesql.squigglesql {
+                                        requires transitive java.sql;
+
+                                        exports com.github.squigglesql.squigglesql;
+                                        exports com.github.squigglesql.squigglesql.alias;
+                                        exports com.github.squigglesql.squigglesql.criteria;
+                                        exports com.github.squigglesql.squigglesql.exception;
+                                        exports com.github.squigglesql.squigglesql.join;
+                                        exports com.github.squigglesql.squigglesql.literal;
+                                        exports com.github.squigglesql.squigglesql.literal.time;
+                                        exports com.github.squigglesql.squigglesql.parameter;
+                                        exports com.github.squigglesql.squigglesql.query;
+                                        exports com.github.squigglesql.squigglesql.statement;
+                                        exports com.github.squigglesql.squigglesql.syntax;
+                                        exports com.github.squigglesql.squigglesql.util;
+                                    }
+                                </moduleInfoSource>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
This adds a module-info using moditect.

This is required to use this with jlink

## Before
![bad](https://github.com/squigglesql/squigglesql/assets/5004262/6c84a469-41b9-4aef-a705-1ece081d4c44)


## After
![demo](https://github.com/squigglesql/squigglesql/assets/5004262/d6b77470-ec7e-4d2e-8f16-1e199e016aaf)
